### PR TITLE
Fix metainfo file

### DIFF
--- a/cc.nift.nsm.appdata.xml
+++ b/cc.nift.nsm.appdata.xml
@@ -27,10 +27,15 @@
   <developer_name>Nick Ham</developer_name>
   <update_contact>contact_at_n-ham.com</update_contact>
 
-  <icon height="128" width="128">$APPID.png</icon>
-  <icon height="64" width="64">$APPID.png</icon>
+  <icon type="stock" height="128" width="128">$APPID</icon>
+  <icon type="stock" height="64" width="64">$APPID</icon>
 
   <launchable type="desktop-id">cc.nift.nsm.desktop</launchable>
+
+  <provides>
+    <binary>nift</binary>
+  </provides>
+
   <releases>
   	<release version="2.4.12" date="2021-04-11" />
     <release version="2.4.11" date="2021-04-09" />


### PR DESCRIPTION
Hi!
This PR fixes a few issues with the metainfo data:
 * Icons *must* have a type property set
 * Stock icons *must not* have a file extension
 * Components of type `console-application` must provide a binary

Given that this app also has a desktop-entry launchable, the icon tags are probably not even needed, but they also don't hurt, so I left them in (and making the metainfo file more complete is not a bad thing).

This PR resolves https://github.com/flathub/cc.nift.nsm/issues/3 and all its connected issues.

Cheers,
    Matthias
